### PR TITLE
Fix chart selection and drag issues

### DIFF
--- a/src/features/dashboard/composables/useDashboardState.ts
+++ b/src/features/dashboard/composables/useDashboardState.ts
@@ -257,6 +257,8 @@ export function useDashboardState() {
       
       // 确保配置面板显示数据源标签页
       activeConfigTab.value = 'dataset'
+      // 选中图表时始终展示配置面板
+      showConfigPanel.value = true
     } else {
       console.warn('未找到图表或图表配置:', chartId, item)
     }
@@ -265,6 +267,7 @@ export function useDashboardState() {
   // 取消选择图表
   const deselectChart = () => {
     selectedChart.value = null
+    showConfigPanel.value = false
   }
   
   // 删除图表

--- a/src/features/dashboard/composables/useDragAndDrop.ts
+++ b/src/features/dashboard/composables/useDragAndDrop.ts
@@ -523,6 +523,8 @@ export function useDragAndDrop() {
     }
     
     layout.push(newItem)
+    // 触发响应式更新，确保新图表可拖拽
+    layout.splice(0, layout.length, ...layout)
     
     nextTick(() => {
       if (isChartType(itemConfig.chartConfig.type)) {


### PR DESCRIPTION
## Summary
- always show config panel when a chart is selected
- ensure config panel hides when deselecting charts
- refresh layout array after adding items so new charts are draggable

## Testing
- `npm install` *(fails: registry.npmmirror.com blocked)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685561ec0d248322bc72d0521fb2daf3